### PR TITLE
FIX: updates component to async categories

### DIFF
--- a/javascripts/custom-category-boxes/connectors/below-site-header/category-banner.js
+++ b/javascripts/custom-category-boxes/connectors/below-site-header/category-banner.js
@@ -1,41 +1,37 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import Category from "discourse/models/category";
 
 export default {
   setupComponent(args, component) {
     withPluginApi("0.1", (api) => {
-      api.onPageChange((url) => {
+      api.onPageChange(async (url) => {
         let show_banner = settings.show_banner;
         let splitURL = url.split("/");
         let html = document.getElementsByTagName("html")[0];
 
         if (splitURL[1] === "c") {
-          let categoryTitle = splitURL[2];
+          let categorySlug = splitURL[2];
 
           let rnd = Math.floor(Math.random() * 4);
           let bg = `${settings.category_background}-${rnd}`;
-
-          let c = this.site.categories.find((cat) => {
-            let name = cat.name.toLowerCase().replace(" ", "-");
-            if (name === categoryTitle.toLowerCase()) {
-              return true;
-            }
-          });
-
-          html.classList.add("category-page-custom-banner");
-
-          component.setProperties({
-            show_banner,
-            title: c.name.replace(/^\w/, (cat) => cat.toUpperCase()),
-            backgroundColor: `#${c.color}65`,
-            backgroundImage: `url(${settings.theme_uploads[bg]})`,
-            border: `1px solid #${c.color}`,
-            boxShadow: `8px 8px 0 #${c.color}32`,
-          });
+          try {
+            let c = await Category.asyncFindBySlugPath(categorySlug);
+            html.classList.add("category-page-custom-banner");
+            component.setProperties({
+              show_banner,
+              title: c.name.replace(/^\w/, (cat) => cat.toUpperCase()),
+              backgroundColor: `#${c.color}65`,
+              backgroundImage: `url(${settings.theme_uploads[bg]})`,
+              border: `1px solid #${c.color}`,
+              boxShadow: `8px 8px 0 #${c.color}32`,
+            });
+          } catch (e) {
+            html.classList.remove("category-page-custom-banner");
+            component.set("show_banner", false);
+          }
         } else {
           html.classList.remove("category-page-custom-banner");
-          component.setProperties({
-            show_banner: false,
-          });
+          component.set("show_banner", false);
         }
       });
     });

--- a/spec/system/category_banner_spec.rb
+++ b/spec/system/category_banner_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe "DiscourseCustomCategoryBoxes - category banner", system: true do
+  fab!(:current_user) { Fabricate(:admin) }
+
+  let(:category_page) { PageObjects::Pages::Category.new }
+
+  context "when using lazy loaded categories" do
+    let(:theme) { Fabricate(:theme) }
+
+    let!(:component) { upload_theme_component(parent_theme_id: theme.id) }
+
+    before do
+      SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
+      theme.set_default!
+      sign_in(current_user)
+    end
+
+    fab!(:category) { Fabricate(:category) }
+    fab!(:topic) { Fabricate(:topic, category: category) }
+    fab!(:post) { Fabricate(:post, topic: topic) }
+
+    it "works" do
+      visit("/")
+
+      find(".badge-category[data-category-id='#{category.id}']").click
+
+      expect(category_page).to have_css(".custom-category-banner-title", text: category.name)
+    end
+  end
+end


### PR DESCRIPTION
When a site had more categories than what we preload by default, visiting a non-preloaded category page would raise an error:

```
client-error-handler.js:125 [THEME 2 'Custom Category Boxes']
TypeError: Cannot read properties of undefined (reading 'name')
    at category-banner.js:31:24
    at plugin-api.js:127:26
    at AppEvents.<anonymous> (plugin-api.js:736:50)
    at m (index.js:200:1)
    at AppEvents.trigger (evented.js:27:1)
    at page-tracker.js:41:17
    at invoke (backburner.js.js:282:1)
    at h.flush (backburner.js.js:197:1)
    at p.flush (backburner.js.js:358:1)
    at B._end (backburner.js.js:798:1)
    at B.end (backburner.js.js:589:1)
    at B._runExpiredTimers (backburner.js.js:905:1)
reportToConsole	@	client-error-handler.js:125
```